### PR TITLE
Fix recurring CVE retrieval failures (migrate to NVD data feeds)

### DIFF
--- a/capec2technique.py
+++ b/capec2technique.py
@@ -30,7 +30,7 @@ def save_jsonl(cve_capec_data):
         # Update the database with the new CVEs
         cve_db = load_db_jsonl(year)
         cve_db.update(cves)
-        with gzip.open(f'database/CVE-{year}.jsonl.gz', 'wt', encoding='utf-8') as f:
+        with gzip.open(f'database/CVE-{year}.jsonl.gz', 'wt', encoding='utf-8', compresslevel=6) as f:
             for cve, data in cve_db.items():
                 f.write(json.dumps({cve: data}) + "\n")
 

--- a/cwe2capec.py
+++ b/cwe2capec.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 
 
@@ -18,18 +17,11 @@ def fetch_capec_for_cwe(cwe: str, cwe_db: dict):
         return []
 
 
-# Process each CWE to extract the related CAPEC entries
+# Process each CWE to extract the related CAPEC entries.
 def process_cwe_to_capec(cwe_list, cwe_db):
     list_capec = set()
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {executor.submit(fetch_capec_for_cwe, cwe, cwe_db): cwe for cwe in cwe_list}
-        for future in as_completed(futures):
-            cwe = futures[future]
-            try:
-                data = future.result()
-                list_capec.update(data)
-            except Exception as e:
-                print(f"Error processing CWE-{cwe}: {str(e)}")
+    for cwe in cwe_list:
+        list_capec.update(fetch_capec_for_cwe(cwe, cwe_db))
     return list(list_capec)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi==2024.8.30
 charset-normalizer==3.4.0
 et-xmlfile==1.1.0
 idna==3.10
+ijson==3.4.0.post0
 numpy==2.1.2
 openpyxl==3.1.5
 pandas==2.2.3

--- a/retrieve_cve.py
+++ b/retrieve_cve.py
@@ -1,81 +1,121 @@
 import requests
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from tqdm import tqdm
 from re import match
 import os
 import time
+import gzip
+import ijson
 
-API_CVES = "https://services.nvd.nist.gov/rest/json/cves/2.0/"
-API_KEY = os.environ.get("NVD_API_KEY")
+# NVD JSON 2.0 data feeds (static files, far more reliable than the date-filtered API).
+# https://nvd.nist.gov/vuln/data-feeds
+FEED_BASE = "https://nvd.nist.gov/feeds/json/cve/2.0/"
+# The "modified" feed contains every CVE added or modified within the previous 8 days.
+MODIFIED_FEED = FEED_BASE + "nvdcve-2.0-modified.json.gz"
+# Year feeds are used as a fallback when the gap to cover exceeds the modified feed window.
+YEAR_FEED = FEED_BASE + "nvdcve-2.0-{year}.json.gz"
+# Safety margin: the modified/recent feeds cover the previous 8 days. Fall back to the
+# year feeds when we need to look further back than this.
+FEED_WINDOW_DAYS = 7
+
 UPDATE_FILE = "lastUpdate.txt"
 CVE_FILE = "results/new_cves.jsonl"
 
-def format_nvd_timestamp(dt: datetime) -> str:
-    dt_utc = dt.astimezone(timezone.utc)
-    return dt_utc.strftime('%Y-%m-%dT%H:%M:%S.000+00:00')
 
-def fetch_data_with_retries(session, url, params=None, retries=3, delay=5):
+def parse_feed_timestamp(value: str) -> datetime:
+    """Parse an NVD feed 'lastModified' value (UTC, no offset) into an aware datetime."""
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def download_feed_with_retries(session, url, dest, retries=3, delay=5):
     for attempt in range(1, retries + 1):
-        response = session.get(url, params=params)
-        if response.status_code == 200:
-            return response
-        elif 500 <= response.status_code < 600:
-            print(f"[-] Failed to download CVE data (attempt {attempt}/{retries}) - Error:{response.status_code}. Retrying in {delay*attempt}s...")
+        try:
+            with session.get(url, stream=True, timeout=120) as response:
+                if response.status_code == 200:
+                    with open(dest, "wb") as f:
+                        for chunk in response.iter_content(chunk_size=1 << 20):
+                            f.write(chunk)
+                    return dest
+                elif 500 <= response.status_code < 600:
+                    print(f"[-] Failed to download {url} (attempt {attempt}/{retries}) - Error:{response.status_code}. Retrying in {delay*attempt}s...")
+                    time.sleep(delay * attempt)
+                    continue
+                else:
+                    raise Exception(f"Failed to download {url} (status code: {response.status_code})")
+        except requests.RequestException as e:
+            print(f"[-] Failed to download {url} (attempt {attempt}/{retries}) - {e}. Retrying in {delay*attempt}s...")
             time.sleep(delay * attempt)
-        else:
-            raise Exception(f"Failed to download CVE data after {retries} attempts (status code: {response.status_code})")
-    raise Exception(f"Failed to download CVE data after {retries} attempts (status code: {response.status_code})")
+    raise Exception(f"Failed to download {url} after {retries} attempts")
 
-def parse_cves(start_date: str, end_date: str):
+
+def feeds_to_fetch(start_date: datetime, end_date: datetime):
+    """Pick the smallest set of feeds covering [start_date, end_date]."""
+    if end_date - start_date <= timedelta(days=FEED_WINDOW_DAYS):
+        return [MODIFIED_FEED]
+    # Larger gap (first run, or the job was down for a while): use the year feeds,
+    # which contain the complete history per year.
+    return [YEAR_FEED.format(year=year) for year in range(start_date.year, end_date.year + 1)]
+
+
+def extract_cwes(cve: dict):
+    """Extract primary CWE codes (falling back to secondary) for a single CVE entry."""
+    cwe_list = []
+    has_primary_cwe = False
+    infos = cve.get("weaknesses", [])
+    if not infos:
+        return cwe_list
+    for cwe in infos:
+        if cwe.get("type", "") == "Primary":
+            cwe_code = cwe.get("description", [])[0].get("value", "")
+            if match(r"CWE-\d{1,4}", cwe_code):
+                cwe_list.append(cwe_code.split("-")[1])
+                has_primary_cwe = True
+    if not has_primary_cwe:
+        for cwe in infos:
+            if cwe.get("type", "") == "Secondary":
+                cwe_code = cwe.get("description", [])[0].get("value", "")
+                if match(r"CWE-\d{1,4}", cwe_code):
+                    cwe_list.append(cwe_code.split("-")[1])
+    return cwe_list
+
+
+def parse_cves(start_date: datetime, end_date: datetime):
     cve_data = {}
     session = requests.Session()
-    session.headers.update({"apiKey": API_KEY})
 
-    params = {
-        "lastModStartDate": start_date,
-        "lastModEndDate": end_date,
-        "resultsPerPage": 2000,
-        "startIndex": 0,
-    }
+    feeds = feeds_to_fetch(start_date, end_date)
+    if feeds == [MODIFIED_FEED]:
+        print(f"[+] Gap <= {FEED_WINDOW_DAYS} days: using the 'modified' feed")
+    else:
+        print(f"[+] Gap > {FEED_WINDOW_DAYS} days: falling back to year feeds {[f.rsplit('-', 1)[-1] for f in feeds]}")
 
-    response = fetch_data_with_retries(session, API_CVES, params)
-    cves = response.json()
-    results_per_page = cves.get("resultsPerPage", 0)
-    total_results = cves.get("totalResults", 0)
+    print(f"[+] ijson backend: {ijson.backend}")
 
-    if results_per_page == 0 or total_results == 0:
+    os.makedirs("feeds_tmp", exist_ok=True)
+    for feed_url in feeds:
+        dest = os.path.join("feeds_tmp", os.path.basename(feed_url))
+        download_feed_with_retries(session, feed_url, dest)
+        with gzip.open(dest, "rb") as f:
+            for cve_wrapper in tqdm(ijson.items(f, "vulnerabilities.item"), desc=f"Processing {os.path.basename(feed_url)}", unit="CVE"):
+                cve = cve_wrapper.get("cve", {})
+                last_modified = cve.get("lastModified")
+                # Keep only CVEs modified since the last run (real delta), so the
+                # downstream pipeline stays as light as it is today.
+                if last_modified and parse_feed_timestamp(last_modified) < start_date:
+                    continue
+                cve_id = cve.get("id", "")
+                if cve_id:
+                    cve_data[cve_id] = {"CWE": extract_cwes(cve)}
+        os.remove(dest)
+
+    if not cve_data:
         print("[-] No new vulnerabilities found")
-        return cve_data
-
-    nb_pages = (total_results + results_per_page - 1) // results_per_page
-
-    for page in tqdm(range(nb_pages), desc="Fetching pages", unit="Page"):
-        params["startIndex"] = page * 2000
-        response = fetch_data_with_retries(session, API_CVES, params)
-        cves = response.json()
-        for cve in tqdm(cves.get("vulnerabilities", []), desc="Processing CVEs", unit="CVE"):
-            has_primary_cwe = False
-            cve_id = cve.get("cve", {}).get("id", "")
-            cwe_list = []
-            infos = cve.get("cve", {}).get("weaknesses", [])
-            if infos:
-                for cwe in infos:
-                    if cwe.get("type", "") == "Primary":
-                        cwe_code = cwe.get("description", [])[0].get("value", "")
-                        if match(r"CWE-\d{1,4}", cwe_code):
-                            cwe_list.append(cwe_code.split("-")[1])
-                            has_primary_cwe = True
-                if not has_primary_cwe:
-                    for cwe in infos:
-                        if cwe.get("type", "") == "Secondary":
-                            cwe_code = cwe.get("description", [])[0].get("value", "")
-                            if match(r"CWE-\d{1,4}", cwe_code):
-                                cwe_list.append(cwe_code.split("-")[1])
-                cve_data[cve_id] = {"CWE": cwe_list}
-            else:
-                cve_data[cve_id] = {"CWE": []}
     return cve_data
+
 
 def save_jsonl(cve_data, today_iso: str):
     os.makedirs(os.path.dirname(CVE_FILE), exist_ok=True)
@@ -86,20 +126,19 @@ def save_jsonl(cve_data, today_iso: str):
     with open(UPDATE_FILE, 'w', encoding='utf-8') as f:
         f.write(today_iso)
 
+
 if __name__ == "__main__":
     today_dt = datetime.now(timezone.utc)
-    today = format_nvd_timestamp(today_dt)
 
     try:
         with open(UPDATE_FILE, 'r') as f:
             last_update_raw = f.read().strip()
         last_update_dt = datetime.fromisoformat(last_update_raw)
-        last_update = format_nvd_timestamp(last_update_dt)
+        if last_update_dt.tzinfo is None:
+            last_update_dt = last_update_dt.replace(tzinfo=timezone.utc)
     except Exception as e:
         print(f"[!] Failed to parse last update date: {e}. Using fallback date.")
         last_update_dt = datetime(2021, 1, 1, tzinfo=timezone.utc)
-        last_update = format_nvd_timestamp(last_update_dt)
 
-    cves_data = parse_cves(last_update, today)
+    cves_data = parse_cves(last_update_dt, today_dt)
     save_jsonl(cves_data, today_dt.isoformat())
-

--- a/technique2atlas.py
+++ b/technique2atlas.py
@@ -25,7 +25,7 @@ def save_jsonl(cve_tech_data):
     for year, cves in new_cves.items():
         cve_db = load_db_jsonl(year)
         cve_db.update(cves)
-        with gzip.open(f'database/CVE-{year}.jsonl.gz', 'wt', encoding='utf-8') as f:
+        with gzip.open(f'database/CVE-{year}.jsonl.gz', 'wt', encoding='utf-8', compresslevel=6) as f:
             for cve, data in cve_db.items():
                 f.write(json.dumps({cve: data}) + "\n")
 

--- a/technique2defend.py
+++ b/technique2defend.py
@@ -31,7 +31,7 @@ def save_jsonl(cve_tech_data):
         # Update the database with the new CVEs
         cve_db = load_db_jsonl(year)
         cve_db.update(cves)
-        with gzip.open(f'database/CVE-{year}.jsonl.gz', 'wt', encoding='utf-8') as f:
+        with gzip.open(f'database/CVE-{year}.jsonl.gz', 'wt', encoding='utf-8', compresslevel=6) as f:
             for cve, data in cve_db.items():
                 f.write(json.dumps({cve: data}) + "\n")
 


### PR DESCRIPTION
The date-filtered NVD API returned recurring 503 errors, breaking the pipeline.

This MR:

- Migrates retrieve_cve.py from the date-filtered API to the static NVD JSON data feeds (reliable, same schema), with a fallback to yearly feeds for large gaps
- Speeds up cwe2capec.py (removed the per-CVE thread pool used for simple dict lookups)
- Lowers gzip compression to level 6 in the DB-writing scripts (~5× faster writes, +5% file size)

Fix #32 